### PR TITLE
fix: change variables names in dashboard

### DIFF
--- a/src/spaceone/dashboard/info/custom_widget_info.py
+++ b/src/spaceone/dashboard/info/custom_widget_info.py
@@ -19,7 +19,7 @@ def CustomWidgetInfo(custom_widget_vo: CustomWidget, minimal=False):
 
     if not minimal:
         info.update({
-            'widget_options': change_struct_type(custom_widget_vo.widget_options),
+            'options': change_struct_type(custom_widget_vo.options),
             'inherit_options': change_struct_type(custom_widget_vo.inherit_options),
             'labels': change_list_value_type(custom_widget_vo.labels),
             'tags': change_struct_type(custom_widget_vo.tags),

--- a/src/spaceone/dashboard/info/domain_dashboard_info.py
+++ b/src/spaceone/dashboard/info/domain_dashboard_info.py
@@ -22,9 +22,9 @@ def DomainDashboardInfo(domain_dashboard_vo: DomainDashboard, minimal=False):
         info.update({
             'layouts': change_list_value_type(
                 domain_dashboard_vo.layouts) if domain_dashboard_vo.layouts else None,
-            'dashboard_options': change_struct_type(domain_dashboard_vo.dashboard_options),
+            'variables': change_struct_type(domain_dashboard_vo.variables),
             'settings': _DomainDashboardSettingsInfo(domain_dashboard_vo.settings),
-            'dashboard_options_schema': change_struct_type(domain_dashboard_vo.dashboard_options_schema),
+            'variables_schema': change_struct_type(domain_dashboard_vo.variables_schema),
             'tags': change_struct_type(domain_dashboard_vo.tags),
             'created_at': utils.datetime_to_iso8601(domain_dashboard_vo.created_at),
             'updated_at': utils.datetime_to_iso8601(domain_dashboard_vo.updated_at)

--- a/src/spaceone/dashboard/info/domain_dashboard_version_info.py
+++ b/src/spaceone/dashboard/info/domain_dashboard_version_info.py
@@ -29,9 +29,9 @@ def DomainDashboardVersionInfo(domain_dashboard_version_vo: DomainDashboardVersi
         info.update({
             'layouts': change_list_value_type(
                 domain_dashboard_version_vo.layouts) if domain_dashboard_version_vo.layouts else None,
-            'dashboard_options': change_struct_type(domain_dashboard_version_vo.dashboard_options),
+            'variables': change_struct_type(domain_dashboard_version_vo.variables),
             'settings': _DomainDashboardVersionSettingsInfo(domain_dashboard_version_vo.settings),
-            'dashboard_options_schema': change_struct_type(domain_dashboard_version_vo.dashboard_options_schema)
+            'variables_schema': change_struct_type(domain_dashboard_version_vo.variables_schema)
         })
 
     return domain_dashboard_pb2.DomainDashboardVersionInfo(**info)

--- a/src/spaceone/dashboard/info/project_dashboard_info.py
+++ b/src/spaceone/dashboard/info/project_dashboard_info.py
@@ -23,9 +23,9 @@ def ProjectDashboardInfo(project_dashboard_vo: ProjectDashboard, minimal=False):
         info.update({
             'layouts': change_list_value_type(
                 project_dashboard_vo.layouts) if project_dashboard_vo.layouts else None,
-            'dashboard_options': change_struct_type(project_dashboard_vo.dashboard_options),
+            'variables': change_struct_type(project_dashboard_vo.variables),
             'settings': _ProjectDashboardSettingsInfo(project_dashboard_vo.settings),
-            'dashboard_options_schema': change_struct_type(project_dashboard_vo.dashboard_options_schema),
+            'variables_schema': change_struct_type(project_dashboard_vo.variables_schema),
             'tags': change_struct_type(project_dashboard_vo.tags),
             'created_at': utils.datetime_to_iso8601(project_dashboard_vo.created_at),
             'updated_at': utils.datetime_to_iso8601(project_dashboard_vo.updated_at)

--- a/src/spaceone/dashboard/info/project_dashboard_version_info.py
+++ b/src/spaceone/dashboard/info/project_dashboard_version_info.py
@@ -30,9 +30,9 @@ def ProjectDashboardVersionInfo(project_dashboard_version_vo: ProjectDashboardVe
         info.update({
             'layouts': change_list_value_type(
                 project_dashboard_version_vo.layouts) if project_dashboard_version_vo.layouts else None,
-            'dashboard_options': change_struct_type(project_dashboard_version_vo.dashboard_options),
+            'variables': change_struct_type(project_dashboard_version_vo.variables),
             'settings': _ProjectDashboardVersionSettingsInfo(project_dashboard_version_vo.settings),
-            'dashboard_options_schema': change_struct_type(project_dashboard_version_vo.dashboard_options_schema)
+            'variables_schema': change_struct_type(project_dashboard_version_vo.variables_schema)
         })
 
     return project_dashboard_pb2.ProjectDashboardVersionInfo(**info)

--- a/src/spaceone/dashboard/manager/domain_dashboard_version_manager.py
+++ b/src/spaceone/dashboard/manager/domain_dashboard_version_manager.py
@@ -22,11 +22,11 @@ class DomainDashboardVersionManager(BaseManager):
             'domain_dashboard_id': domain_dashboard_vo.domain_dashboard_id,
             'version': domain_dashboard_vo.version,
             'layouts': params.get('layouts') if params.get('layouts') else domain_dashboard_vo.layouts,
-            'dashboard_options': params.get('dashboard_options') if params.get(
-                'dashboard_options') else domain_dashboard_vo.dashboard_options,
+            'variables': params.get('variables') if params.get(
+                'variables') else domain_dashboard_vo.variables,
             'settings': params.get('settings') if params.get('settings') else domain_dashboard_vo.settings.to_dict(),
-            'dashboard_options_schema': params.get('dashboard_options_schema') if params.get(
-                'dashboard_options_schema') else domain_dashboard_vo.dashboard_options_schema,
+            'variables_schema': params.get('variables_schema') if params.get(
+                'variables_schema') else domain_dashboard_vo.variables_schema,
             'domain_id': domain_dashboard_vo.domain_id
         }
 

--- a/src/spaceone/dashboard/manager/project_dashboard_version_manager.py
+++ b/src/spaceone/dashboard/manager/project_dashboard_version_manager.py
@@ -23,11 +23,11 @@ class ProjectDashboardVersionManager(BaseManager):
             'project_dashboard_id': project_dashboard_vo.project_dashboard_id,
             'version': project_dashboard_vo.version,
             'layouts': params.get('layouts') if params.get('layouts') else project_dashboard_vo.layouts,
-            'dashboard_options': params.get('dashboard_options') if params.get(
-                'dashboard_options') else project_dashboard_vo.dashboard_options,
+            'variables': params.get('variables') if params.get(
+                'variables') else project_dashboard_vo.variables,
             'settings': params.get('settings') if params.get('settings') else project_dashboard_vo.settings.to_dict(),
-            'dashboard_options_schema': params.get('dashboard_options_schema') if params.get(
-                'dashboard_options_schema') else project_dashboard_vo.dashboard_options_schema,
+            'variables_schema': params.get('variables_schema') if params.get(
+                'variables_schema') else project_dashboard_vo.variables_schema,
             'domain_id': project_dashboard_vo.domain_id
         }
 

--- a/src/spaceone/dashboard/model/custom_widget_model.py
+++ b/src/spaceone/dashboard/model/custom_widget_model.py
@@ -8,7 +8,7 @@ class CustomWidget(MongoModel):
     widget_name = StringField(max_length=40)
     title = StringField(max_length=255)
     version = StringField(max_length=40)
-    widget_options = DictField(default={})
+    options = DictField(default={})
     inherit_options = DictField(default={})
     labels = ListField(StringField())
     tags = DictField(default={})
@@ -21,7 +21,7 @@ class CustomWidget(MongoModel):
         'updatable_fields': [
             'widget_name',
             'title',
-            'widget_options',
+            'options',
             'inherit_options',
             'labels',
             'tags'

--- a/src/spaceone/dashboard/model/domain_dashboard_model.py
+++ b/src/spaceone/dashboard/model/domain_dashboard_model.py
@@ -25,9 +25,9 @@ class DomainDashboard(MongoModel):
     viewers = StringField(max_length=255, choices=('PUBLIC', 'PRIVATE'))
     version = IntField(default=1)
     layouts = ListField(DictField(default={}))
-    dashboard_options = DictField(default={})
+    variables = DictField(default={})
     settings = EmbeddedDocumentField(Settings, default=Settings)
-    dashboard_options_schema = DictField(default={})
+    variables_schema = DictField(default={})
     labels = ListField(StringField())
     tags = DictField(default={})
     user_id = StringField(max_length=40)
@@ -39,9 +39,9 @@ class DomainDashboard(MongoModel):
         'updatable_fields': [
             'name',
             'layouts',
-            'dashboard_options',
+            'variables',
             'settings',
-            'dashboard_options_schema',
+            'variables_schema',
             'labels',
             'tags'
         ],

--- a/src/spaceone/dashboard/model/domain_dashboard_version_model.py
+++ b/src/spaceone/dashboard/model/domain_dashboard_version_model.py
@@ -20,9 +20,9 @@ class DomainDashboardVersion(MongoModel):
     domain_dashboard_id = StringField(max_length=40)
     version = IntField()
     layouts = ListField(DictField(default={}))
-    dashboard_options = DictField(default={})
+    variables = DictField(default={})
     settings = EmbeddedDocumentField(Settings, default=Settings)
-    dashboard_options_schema = DictField(default={})
+    variables_schema = DictField(default={})
     domain_id = StringField(max_length=40)
     created_at = DateTimeField(auto_now_add=True)
 

--- a/src/spaceone/dashboard/model/project_dashboard_model.py
+++ b/src/spaceone/dashboard/model/project_dashboard_model.py
@@ -25,9 +25,9 @@ class ProjectDashboard(MongoModel):
     viewers = StringField(max_length=255, choices=('PUBLIC', 'PRIVATE'))
     version = IntField(default=1)
     layouts = ListField(DictField(default={}))
-    dashboard_options = DictField(default={})
+    variables = DictField(default={})
     settings = EmbeddedDocumentField(Settings, default=Settings)
-    dashboard_options_schema = DictField(default={})
+    variables_schema = DictField(default={})
     labels = ListField(StringField())
     tags = DictField(default={})
     user_id = StringField(max_length=40)
@@ -40,9 +40,9 @@ class ProjectDashboard(MongoModel):
         'updatable_fields': [
             'name',
             'layouts',
-            'dashboard_options',
+            'variables',
             'settings',
-            'dashboard_options_schema',
+            'variables_schema',
             'labels',
             'tags'
         ],

--- a/src/spaceone/dashboard/model/project_dashboard_version_model.py
+++ b/src/spaceone/dashboard/model/project_dashboard_version_model.py
@@ -20,9 +20,9 @@ class ProjectDashboardVersion(MongoModel):
     project_dashboard_id = StringField(max_length=40)
     version = IntField()
     layouts = ListField(DictField(default={}))
-    dashboard_options = DictField(default={})
+    variables = DictField(default={})
     settings = EmbeddedDocumentField(Settings, default=Settings)
-    dashboard_options_schema = DictField(default={})
+    variables_schema = DictField(default={})
     domain_id = StringField(max_length=40)
     created_at = DateTimeField(auto_now_add=True)
 

--- a/src/spaceone/dashboard/service/custom_widget_service.py
+++ b/src/spaceone/dashboard/service/custom_widget_service.py
@@ -18,7 +18,7 @@ class CustomWidgetService(BaseService):
         self.custom_widget_mgr: CustomWidgetManager = self.locator.get_manager('CustomWidgetManager')
 
     @transaction(append_meta={'authorization.scope': 'USER'})
-    @check_required(['widget_name', 'title', 'widget_options', 'domain_id'])
+    @check_required(['widget_name', 'title', 'options', 'domain_id'])
     def create(self, params):
         """Register widget
 
@@ -26,7 +26,7 @@ class CustomWidgetService(BaseService):
             params (dict): {
                 'widget_name': 'str',
                 'title': 'str',
-                'widget_options': 'dict',
+                'options': 'dict',
                 'inherit_options': 'dict',
                 'labels': 'list',
                 'tags': 'dict',
@@ -50,7 +50,7 @@ class CustomWidgetService(BaseService):
             params (dict): {
                 'custom_widget_id': 'str',
                 'title': 'str',
-                'widget_options': 'dict',
+                'options': 'dict',
                 'inherit_option': 'dict',
                 'labels': 'list',
                 'tags': 'dict',

--- a/src/spaceone/dashboard/service/domain_dashboard_service.py
+++ b/src/spaceone/dashboard/service/domain_dashboard_service.py
@@ -29,9 +29,9 @@ class DomainDashboardService(BaseService):
                 'name': 'str',
                 'viewers': 'str',
                 'layouts': 'list',
-                'dashboard_options': 'dict',
+                'variables': 'dict',
                 'settings': 'dict',
-                'dashboard_options_schema': 'dict',
+                'variables_schema': 'dict',
                 'labels': 'list',
                 'tags': 'dict',
                 'domain_id': 'str'
@@ -48,7 +48,7 @@ class DomainDashboardService(BaseService):
 
         domain_dashboard_vo = self.domain_dashboard_mgr.create_domain_dashboard(params)
 
-        version_keys = ['layouts', 'dashboard_options', 'dashboard_options_schema']
+        version_keys = ['layouts', 'variables', 'variables_schema']
         if any(set(version_keys) & set(params.keys())):
             self.version_mgr.create_version_by_domain_dashboard_vo(domain_dashboard_vo, params)
 
@@ -64,9 +64,9 @@ class DomainDashboardService(BaseService):
                 'domain_dashboard_id': 'str',
                 'name': 'str',
                 'layouts': 'list',
-                'dashboard_options': 'dict',
+                'variables': 'dict',
                 'settings': 'dict',
-                'dashboard_options_schema': 'list',
+                'variables_schema': 'list',
                 'labels': 'list',
                 'tags': 'dict',
                 'domain_id': 'str'
@@ -89,7 +89,7 @@ class DomainDashboardService(BaseService):
         if 'settings' in params:
             params['settings'] = self._create_settings_in_params(domain_dashboard_vo, params['settings'])
 
-        version_change_keys = ['layouts', 'dashboard_options', 'dashboard_options_schema']
+        version_change_keys = ['layouts', 'variables', 'variables_schema']
         if self._has_version_key_in_params(domain_dashboard_vo, params, version_change_keys):
             self.domain_dashboard_mgr.increase_version(domain_dashboard_vo)
             self.version_mgr.create_version_by_domain_dashboard_vo(domain_dashboard_vo, params)
@@ -213,8 +213,8 @@ class DomainDashboardService(BaseService):
         version_vo: DomainDashboardVersion = self.version_mgr.get_version(domain_dashboard_id, version, domain_id)
 
         params['layouts'] = version_vo.layouts
-        params['dashboard_options'] = version_vo.dashboard_options
-        params['dashboard_options_schema'] = version_vo.dashboard_options_schema
+        params['variables'] = version_vo.variables
+        params['variables_schema'] = version_vo.variables_schema
 
         self.domain_dashboard_mgr.increase_version(domain_dashboard_vo)
         self.version_mgr.create_version_by_domain_dashboard_vo(domain_dashboard_vo, params)
@@ -346,18 +346,18 @@ class DomainDashboardService(BaseService):
     @staticmethod
     def _has_version_key_in_params(domain_dashboard_vo, params, version_change_keys):
         layouts = domain_dashboard_vo.layouts
-        dashboard_options = domain_dashboard_vo.dashboard_options
-        dashboard_options_schema = domain_dashboard_vo.dashboard_options_schema
+        variables = domain_dashboard_vo.variables
+        variables_schema = domain_dashboard_vo.variables_schema
 
         if any(key for key in params if key in version_change_keys):
             if layouts_from_params := params.get('layouts'):
                 if layouts != layouts_from_params:
                     return True
-            if options_from_params := params.get('dashboard_options'):
-                if dashboard_options != options_from_params:
+            if options_from_params := params.get('variables'):
+                if variables != options_from_params:
                     return True
-            if schema_from_params := params.get('dashboard_options_schema'):
-                if schema_from_params != dashboard_options_schema:
+            if schema_from_params := params.get('variables_schema'):
+                if schema_from_params != variables_schema:
                     return True
             return False
 

--- a/src/spaceone/dashboard/service/project_dashboard_service.py
+++ b/src/spaceone/dashboard/service/project_dashboard_service.py
@@ -30,9 +30,9 @@ class ProjectDashboardService(BaseService):
                 'name': 'str',
                 'viewers': 'str',
                 'layouts': 'list',
-                'dashboard_options': 'dict',
+                'variables': 'dict',
                 'settings': 'dict',
-                'dashboard_options_schema': 'dict',
+                'variables_schema': 'dict',
                 'labels': 'list',
                 'tags': 'dict',
                 'domain_id': 'str'
@@ -49,7 +49,7 @@ class ProjectDashboardService(BaseService):
 
         project_dashboard_vo = self.project_dashboard_mgr.create_project_dashboard(params)
 
-        version_keys = ['layouts', 'dashboard_options', 'dashboard_options_schema']
+        version_keys = ['layouts', 'variables', 'variables_schema']
         if any(set(version_keys) & set(params.keys())):
             self.version_mgr.create_version_by_project_dashboard_vo(project_dashboard_vo, params)
 
@@ -65,9 +65,9 @@ class ProjectDashboardService(BaseService):
                 'project_dashboard_id': 'str',
                 'name': 'str',
                 'layouts': 'list',
-                'dashboard_options': 'dict',
+                'variables': 'dict',
                 'settings': 'dict',
-                'dashboard_options_schema': 'dict',
+                'variables_schema': 'dict',
                 'labels': 'list',
                 'tags': 'dict',
                 'domain_id': 'str'
@@ -90,7 +90,7 @@ class ProjectDashboardService(BaseService):
         if 'settings' in params:
             params['settings'] = self._create_settings_in_params(project_dashboard_vo, params['settings'])
 
-        version_change_keys = ['layouts', 'dashboard_options', 'dashboard_options_schema']
+        version_change_keys = ['layouts', 'variables', 'variables_schema']
         if self._has_version_key_in_params(project_dashboard_vo, params, version_change_keys):
             self.project_dashboard_mgr.increase_version(project_dashboard_vo)
             self.version_mgr.create_version_by_project_dashboard_vo(project_dashboard_vo, params)
@@ -213,8 +213,8 @@ class ProjectDashboardService(BaseService):
         version_vo: ProjectDashboardVersion = self.version_mgr.get_version(project_dashboard_id, version, domain_id)
 
         params['layouts'] = version_vo.layouts
-        params['dashboard_options'] = version_vo.dashboard_options
-        params['dashboard_options_schema'] = version_vo.dashboard_options_schema
+        params['variables'] = version_vo.variables
+        params['variables_schema'] = version_vo.variables_schema
 
         self.project_dashboard_mgr.increase_version(project_dashboard_vo)
         self.version_mgr.create_version_by_project_dashboard_vo(project_dashboard_vo, params)
@@ -350,18 +350,18 @@ class ProjectDashboardService(BaseService):
     @staticmethod
     def _has_version_key_in_params(domain_dashboard_vo, params, version_change_keys):
         layouts = domain_dashboard_vo.layouts
-        dashboard_options = domain_dashboard_vo.dashboard_options
-        dashboard_options_schema = domain_dashboard_vo.dashboard_options_schema
+        variables = domain_dashboard_vo.variables
+        variables_schema = domain_dashboard_vo.variables_schema
 
         if any(key for key in params if key in version_change_keys):
             if layouts_from_params := params.get('layouts'):
                 if layouts != layouts_from_params:
                     return True
-            if options_from_params := params.get('dashboard_options'):
-                if dashboard_options != options_from_params:
+            if options_from_params := params.get('variables'):
+                if variables != options_from_params:
                     return True
-            if schema_from_params := params.get('dashboard_options_schema'):
-                if schema_from_params != dashboard_options_schema:
+            if schema_from_params := params.get('variables_schema'):
+                if schema_from_params != variables_schema:
                     return True
             return False
 

--- a/test/factory/custom_widget_dashboard_factory.py
+++ b/test/factory/custom_widget_dashboard_factory.py
@@ -12,7 +12,7 @@ class CustomWidgetFactory(factory.mongoengine.MongoEngineFactory):
     widget_name = factory.LazyAttribute(lambda o: utils.random_string())
     title = factory.LazyAttribute(lambda o: utils.random_string())
     version = 'v1'
-    widget_options = {
+    options = {
         'group_by': 'product',
     }
     inherit_options = {

--- a/test/factory/domain_dashboard_factory.py
+++ b/test/factory/domain_dashboard_factory.py
@@ -11,7 +11,7 @@ class DomainDashboardFactory(factory.mongoengine.MongoEngineFactory):
     domain_dashboard_id = factory.LazyAttribute(lambda o: utils.generate_id('domain-dash'))
     name = factory.LazyAttribute(lambda o: utils.random_string())
     layouts = []
-    dashboard_options = {
+    variables = {
         'group_by': 'product',
         'project_id': []
     }
@@ -19,7 +19,7 @@ class DomainDashboardFactory(factory.mongoengine.MongoEngineFactory):
         'date_range': {'enabled': True},
         'currency': {'enabled': True},
     }
-    dashboard_options_schema = {}
+    variables_schema = {}
     labels = ['a', 'b', 'c']
     tags = {'type': 'test',
             'env': 'dev'}

--- a/test/factory/domain_dashboard_version_factory.py
+++ b/test/factory/domain_dashboard_version_factory.py
@@ -10,7 +10,7 @@ class DomainDashboardVersionFactory(factory.mongoengine.MongoEngineFactory):
 
     # domain_dashboard_id = factory.LazyAttribute(lambda o: utils.generate_id('domain-dash'))
     layouts = [{'name': 'widget1'}, {'name': 'widget2'}, {'name': 'widget3'}]
-    dashboard_options = {
+    variables = {
         'group_by': 'product',
         'project_id': []
     }
@@ -18,6 +18,6 @@ class DomainDashboardVersionFactory(factory.mongoengine.MongoEngineFactory):
         'date_range': {'enabled': True},
         'currency': {'enabled': True},
     }
-    dashboard_options_schema = {'a': 'b'}
+    variables_schema = {'a': 'b'}
     domain_id = factory.LazyAttribute(lambda o: utils.generate_id('domain'))
     created_at = factory.Faker('date_time')

--- a/test/factory/project_dashboard_factory.py
+++ b/test/factory/project_dashboard_factory.py
@@ -12,7 +12,7 @@ class ProjectDashboardFactory(factory.mongoengine.MongoEngineFactory):
     project_id = factory.LazyAttribute(lambda o: utils.generate_id('project'))
     name = factory.LazyAttribute(lambda o: utils.random_string())
     layouts = []
-    dashboard_options = {
+    variables = {
         'group_by': 'product',
         'project_id': []
     }
@@ -20,7 +20,7 @@ class ProjectDashboardFactory(factory.mongoengine.MongoEngineFactory):
         'date_range': {'enabled': True},
         'currency': {'enabled': True},
     }
-    dashboard_options_schema = {}
+    variables_schema = {}
     labels = ['a', 'b', 'c']
     tags = {'type': 'test',
             'env': 'dev'}

--- a/test/factory/project_dashboard_version_factory.py
+++ b/test/factory/project_dashboard_version_factory.py
@@ -10,7 +10,7 @@ class ProjectDashboardVersionFactory(factory.mongoengine.MongoEngineFactory):
 
     # project_dashboard_id = factory.LazyAttribute(lambda o: utils.generate_id('project-dash'))
     layouts = [{'name': 'widget1'}, {'name': 'widget2'}, {'name': 'widget3'}]
-    dashboard_options = {
+    variables = {
         'group_by': 'product',
         'project_id': []
     }
@@ -18,6 +18,6 @@ class ProjectDashboardVersionFactory(factory.mongoengine.MongoEngineFactory):
         'date_range': {'enabled': True},
         'currency': {'enabled': True},
     }
-    dashboard_options_schema = {'a': 'b'}
+    variables_schema = {'a': 'b'}
     domain_id = factory.LazyAttribute(lambda o: utils.generate_id('domain'))
     created_at = factory.Faker('date_time')

--- a/test/service/test_custom_widget.py
+++ b/test/service/test_custom_widget.py
@@ -44,7 +44,7 @@ class TestCustomWidgetService(unittest.TestCase):
             'widget_name': 'widget-name',
             'title': 'test',
             'version': 'v1',
-            'widget_options': {'group_by': 'product'},
+            'options': {'group_by': 'product'},
             'inherit_options': {'a': {'enabled': True}},
             'tags': {'type': 'test'},
             'domain_id': 'domain-12345'
@@ -66,7 +66,7 @@ class TestCustomWidgetService(unittest.TestCase):
         params = {
             'custom_widget_id': custom_widget_vo.custom_widget_id,
             'title': 'update widget test',
-            'widget_options': {'group_by': 'product2'},
+            'options': {'group_by': 'product2'},
             'inherit_options': {'b': {'enabled': True}},
             'tags': {'type': 'test from params'},
             'domain_id': self.domain_id

--- a/test/service/test_domain_dashboard.py
+++ b/test/service/test_domain_dashboard.py
@@ -49,7 +49,7 @@ class TestDomainDashboardService(unittest.TestCase):
             'name': 'test',
             'viewers': 'PUBLIC',
             'domain_id': 'domain-12345',
-            'dashboard_options': {
+            'variables': {
                 'project_id': 'project-1234'
             },
             'settings': {
@@ -71,8 +71,8 @@ class TestDomainDashboardService(unittest.TestCase):
 
         self.assertIsInstance(domain_dashboard_vo, DomainDashboard)
         self.assertEqual(params['name'], domain_dashboard_vo.name)
-        self.assertEqual(params['dashboard_options']['project_id'],
-                         domain_dashboard_vo.dashboard_options.get('project_id'))
+        self.assertEqual(params['variables']['project_id'],
+                         domain_dashboard_vo.variables.get('project_id'))
 
     def test_update_domain_dashboard(self):
         domain_dashboard_vo = DomainDashboardFactory(domain_id=self.domain_id)
@@ -146,9 +146,9 @@ class TestDomainDashboardService(unittest.TestCase):
         DomainDashboardVersionFactory(
             domain_dashboard_id=domain_dashboard_vo.domain_dashboard_id,
             layouts=domain_dashboard_vo.layouts,
-            dashboard_options=domain_dashboard_vo.dashboard_options,
+            variables=domain_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=domain_dashboard_vo.dashboard_options_schema,
+            variables_schema=domain_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -198,9 +198,9 @@ class TestDomainDashboardService(unittest.TestCase):
         first_version = DomainDashboardVersionFactory(
             domain_dashboard_id=domain_dashboard_vo.domain_dashboard_id,
             layouts=domain_dashboard_vo.layouts,
-            dashboard_options=domain_dashboard_vo.dashboard_options,
+            variables=domain_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=domain_dashboard_vo.dashboard_options_schema,
+            variables_schema=domain_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -234,17 +234,17 @@ class TestDomainDashboardService(unittest.TestCase):
         self.assertIsInstance(domain_dashboard_vo, DomainDashboard)
         self.assertEqual(domain_dashboard_vo.version, 3)
         self.assertEqual(domain_dashboard_vo.layouts, first_version.layouts)
-        self.assertEqual(domain_dashboard_vo.dashboard_options, first_version.dashboard_options)
-        self.assertEqual(domain_dashboard_vo.dashboard_options_schema, first_version.dashboard_options_schema)
+        self.assertEqual(domain_dashboard_vo.variables, first_version.variables)
+        self.assertEqual(domain_dashboard_vo.variables_schema, first_version.variables_schema)
 
     def test_get_version(self):
         domain_dashboard_vo = DomainDashboardFactory(domain_id=self.domain_id)
         DomainDashboardVersionFactory(
             domain_dashboard_id=domain_dashboard_vo.domain_dashboard_id,
             layouts=domain_dashboard_vo.layouts,
-            dashboard_options=domain_dashboard_vo.dashboard_options,
+            variables=domain_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=domain_dashboard_vo.dashboard_options_schema,
+            variables_schema=domain_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -264,9 +264,9 @@ class TestDomainDashboardService(unittest.TestCase):
         self.assertEqual(domain_dashboard_version_vo.version, 1)
         self.assertEqual(domain_dashboard_version_vo.domain_dashboard_id, domain_dashboard_vo.domain_dashboard_id)
         self.assertEqual(domain_dashboard_version_vo.layouts, domain_dashboard_vo.layouts)
-        self.assertEqual(domain_dashboard_version_vo.dashboard_options, domain_dashboard_vo.dashboard_options)
-        self.assertEqual(domain_dashboard_version_vo.dashboard_options_schema,
-                         domain_dashboard_vo.dashboard_options_schema)
+        self.assertEqual(domain_dashboard_version_vo.variables, domain_dashboard_vo.variables)
+        self.assertEqual(domain_dashboard_version_vo.variables_schema,
+                         domain_dashboard_vo.variables_schema)
 
     def test_list_versions(self):
         domain_dashboard_vo = DomainDashboardFactory(domain_id=self.domain_id)

--- a/test/service/test_project_dashboard.py
+++ b/test/service/test_project_dashboard.py
@@ -50,7 +50,7 @@ class TestProjectDashboardService(unittest.TestCase):
             'name': 'test',
             'viewers': 'PUBLIC',
             'domain_id': 'domain-12345',
-            'dashboard_options': {
+            'variables': {
                 'project_id': 'project-1234'
             },
             'settings': {
@@ -72,8 +72,8 @@ class TestProjectDashboardService(unittest.TestCase):
 
         self.assertIsInstance(project_dashboard_vo, ProjectDashboard)
         self.assertEqual(params['name'], project_dashboard_vo.name)
-        self.assertEqual(params['dashboard_options']['project_id'],
-                         project_dashboard_vo.dashboard_options.get('project_id'))
+        self.assertEqual(params['variables']['project_id'],
+                         project_dashboard_vo.variables.get('project_id'))
 
     def test_update_project_dashboard(self):
         project_dashboard_vo = ProjectDashboardFactory(domain_id=self.domain_id)
@@ -147,9 +147,9 @@ class TestProjectDashboardService(unittest.TestCase):
         ProjectDashboardVersionFactory(
             project_dashboard_id=project_dashboard_vo.project_dashboard_id,
             layouts=project_dashboard_vo.layouts,
-            dashboard_options=project_dashboard_vo.dashboard_options,
+            variables=project_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=project_dashboard_vo.dashboard_options_schema,
+            variables_schema=project_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -198,9 +198,9 @@ class TestProjectDashboardService(unittest.TestCase):
         first_version = ProjectDashboardVersionFactory(
             project_dashboard_id=project_dashboard_vo.project_dashboard_id,
             layouts=project_dashboard_vo.layouts,
-            dashboard_options=project_dashboard_vo.dashboard_options,
+            variables=project_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=project_dashboard_vo.dashboard_options_schema,
+            variables_schema=project_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -234,17 +234,17 @@ class TestProjectDashboardService(unittest.TestCase):
         self.assertIsInstance(project_dashboard_vo, ProjectDashboard)
         self.assertEqual(project_dashboard_vo.version, 3)
         self.assertEqual(project_dashboard_vo.layouts, first_version.layouts)
-        self.assertEqual(project_dashboard_vo.dashboard_options, first_version.dashboard_options)
-        self.assertEqual(project_dashboard_vo.dashboard_options_schema, first_version.dashboard_options_schema)
+        self.assertEqual(project_dashboard_vo.variables, first_version.variables)
+        self.assertEqual(project_dashboard_vo.variables_schema, first_version.variables_schema)
 
     def test_get_version(self):
         project_dashboard_vo = ProjectDashboardFactory(domain_id=self.domain_id)
         ProjectDashboardVersionFactory(
             project_dashboard_id=project_dashboard_vo.project_dashboard_id,
             layouts=project_dashboard_vo.layouts,
-            dashboard_options=project_dashboard_vo.dashboard_options,
+            variables=project_dashboard_vo.variables,
             version=1,
-            dashboard_options_schema=project_dashboard_vo.dashboard_options_schema,
+            variables_schema=project_dashboard_vo.variables_schema,
             domain_id=self.domain_id
         )
 
@@ -264,9 +264,9 @@ class TestProjectDashboardService(unittest.TestCase):
         self.assertEqual(project_dashboard_version_vo.version, 1)
         self.assertEqual(project_dashboard_version_vo.project_dashboard_id, project_dashboard_vo.project_dashboard_id)
         self.assertEqual(project_dashboard_version_vo.layouts, project_dashboard_vo.layouts)
-        self.assertEqual(project_dashboard_version_vo.dashboard_options, project_dashboard_vo.dashboard_options)
-        self.assertEqual(project_dashboard_version_vo.dashboard_options_schema,
-                         project_dashboard_vo.dashboard_options_schema)
+        self.assertEqual(project_dashboard_version_vo.variables, project_dashboard_vo.variables)
+        self.assertEqual(project_dashboard_version_vo.variables_schema,
+                         project_dashboard_vo.variables_schema)
 
     def test_list_versions(self):
         project_dashboard_vo = ProjectDashboardFactory(domain_id=self.domain_id)


### PR DESCRIPTION
Signed-off-by: seolmin <seolmin@megazone.com>

### Category
- [ ] New feature
- [ ] Bug fix
- [ ] Improvement
- [x] Refactor
- [ ] etc

### Description
change variables names in dashboard

[Domain/Project Dashboard]
`dashboard_options` -> `variables`
`dashboard_options_schema` -> `variables_schema`

[Widget]
`widget_options` -> `options`
