### PR TITLE
Modify to_dict method not to work if it is not a MongoModel

### DIFF
--- a/src/spaceone/dashboard/manager/project_dashboard_version_manager.py
+++ b/src/spaceone/dashboard/manager/project_dashboard_version_manager.py
@@ -25,7 +25,7 @@ class ProjectDashboardVersionManager(BaseManager):
             'layouts': params.get('layouts') if params.get('layouts') else project_dashboard_vo.layouts,
             'variables': params.get('variables') if params.get(
                 'variables') else project_dashboard_vo.variables,
-            'settings': params.get('settings') if params.get('settings') else project_dashboard_vo.settings.to_dict(),
+            'settings': params.get('settings') if params.get('settings') else project_dashboard_vo.settings,
             'variables_schema': params.get('variables_schema') if params.get(
                 'variables_schema') else project_dashboard_vo.variables_schema,
             'domain_id': project_dashboard_vo.domain_id


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
* Modify to_dict method not to work if it is not a MongoModel