### PR TITLE
fix: delete project_id variable when creating PrivateDashboard

### DIFF
--- a/src/spaceone/dashboard/model/private_dashboard_model.py
+++ b/src/spaceone/dashboard/model/private_dashboard_model.py
@@ -55,7 +55,6 @@ class PrivateDashboard(MongoModel):
         dashboard_vos = cls.filter(
             name=data["name"],
             user_id=data["user_id"],
-            project_id=data["project_id"],
             workspace_id=data["workspace_id"],
             domain_id=data["domain_id"],
         )


### PR DESCRIPTION
### Category
- [ ] New feature
- [x] Bug fix
- [ ] Improvement
- [ ] Refactor
- [ ] etc

### Description
* Delete project_id variable when creating PrivateDashboard
